### PR TITLE
Fix typo in comment and remove unused datatype attribute in SinglePag…

### DIFF
--- a/client/src/components/single-page-form/singlePageForm.jsx
+++ b/client/src/components/single-page-form/singlePageForm.jsx
@@ -20,7 +20,7 @@ export default function SinglePageForm() {
 			}
 			onError={(error) => console.error(error)}
 		>
-			{/* Change to a empty string to trigger an error */}
+			{/* Change to an empty string to trigger an error */}
 			<SinglePageFormContent boundaryTest={1} />
 		</ErrorBoundary>
 	);
@@ -304,7 +304,6 @@ export function SinglePageFormContent({ boundaryTest }) {
 					onBlur={changeData}
 					required={true}
 					pattern="\d{4}-\d{2}-\d{2}"
-					datatype="date"
 					min={tomorrow}
 					max={fortnight}
 				/>


### PR DESCRIPTION
This pull request includes minor changes to the `client/src/components/single-page-form/singlePageForm.jsx` file to fix a typo and clean up the code.

Code improvements:

* Fixed a typo in the comment within the `SinglePageForm` function.
* Removed the unnecessary `datatype` attribute from an input element in the `SinglePageFormContent` function.